### PR TITLE
feat: support new memory api

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -31,7 +31,7 @@ export class MastraClient extends BaseResource {
      * @returns Promise containing array of memory threads
      */
     public getMemoryThreads(params: GetMemoryThreadParams): Promise<GetMemoryThreadResponse> {
-        return this.request(`/api/memory/threads?resourceid=${params.resourceId}`);
+        return this.request(`/api/memory/threads?resourceid=${params.resourceId}&agentId=${params.agentId}`);
     }
 
     /**
@@ -40,7 +40,7 @@ export class MastraClient extends BaseResource {
      * @returns Promise containing the created memory thread
      */
     public createMemoryThread(params: CreateMemoryThreadParams): Promise<CreateMemoryThreadResponse> {
-        return this.request('/api/memory/threads', { method: 'POST', body: params });
+        return this.request(`/api/memory/threads?agentId=${params.agentId}`, { method: 'POST', body: params });
     }
 
     /**
@@ -48,8 +48,8 @@ export class MastraClient extends BaseResource {
      * @param threadId - ID of the memory thread to retrieve
      * @returns MemoryThread instance
      */
-    public getMemoryThread(threadId: string) {
-        return new MemoryThread(this.options, threadId);
+    public getMemoryThread(threadId: string, agentId: string) {
+        return new MemoryThread(this.options, threadId, agentId);
     }
 
     /**
@@ -58,7 +58,7 @@ export class MastraClient extends BaseResource {
      * @returns Promise containing the saved messages
      */
     public saveMessageToMemory(params: SaveMessageToMemoryParams): Promise<SaveMessageToMemoryResponse> {
-        return this.request('/api/memory/save-messages', {
+        return this.request(`/api/memory/save-messages?agentId=${params.agentId}`, {
             method: 'POST',
             body: params,
         });
@@ -68,8 +68,8 @@ export class MastraClient extends BaseResource {
      * Gets the status of the memory system
      * @returns Promise containing memory system status
      */
-    public getMemoryStatus(): Promise<{ result: boolean }> {
-        return this.request('/api/memory/status');
+    public getMemoryStatus(agentId: string): Promise<{ result: boolean }> {
+        return this.request(`/api/memory/status?agentId=${agentId}`);
     }
 
     /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -326,12 +326,14 @@ describe('MastraClient Resources', () => {
         });
     });
 
+    const agentId = 'test-agent'
+
     describe('Memory Thread Resource', () => {
         const threadId = 'test-thread';
         let memoryThread: ReturnType<typeof client.getMemoryThread>;
 
         beforeEach(() => {
-            memoryThread = client.getMemoryThread(threadId);
+            memoryThread = client.getMemoryThread(threadId, agentId);
         });
 
         it('should get thread details', async () => {
@@ -345,7 +347,7 @@ describe('MastraClient Resources', () => {
             const result = await memoryThread.get();
             expect(result).toEqual(mockResponse);
             expect(global.fetch).toHaveBeenCalledWith(
-                `${clientOptions.baseUrl}/api/memory/threads/test-thread`,
+                `${clientOptions.baseUrl}/api/memory/threads/test-thread?agentId=${agentId}`,
                 expect.objectContaining({
                     headers: expect.objectContaining(clientOptions.headers)
                 })
@@ -367,7 +369,7 @@ describe('MastraClient Resources', () => {
             });
             expect(result).toEqual(mockResponse);
             expect(global.fetch).toHaveBeenCalledWith(
-                `${clientOptions.baseUrl}/api/memory/threads/test-thread`,
+                `${clientOptions.baseUrl}/api/memory/threads/test-thread?agentId=${agentId}`,
                 expect.objectContaining({
                     method: 'PATCH',
                     headers: expect.objectContaining(clientOptions.headers)
@@ -381,7 +383,7 @@ describe('MastraClient Resources', () => {
             const result = await memoryThread.delete();
             expect(result).toEqual(mockResponse);
             expect(global.fetch).toHaveBeenCalledWith(
-                `${clientOptions.baseUrl}/api/memory/threads/test-thread`,
+                `${clientOptions.baseUrl}/api/memory/threads/test-thread?agentId=${agentId}`,
                 expect.objectContaining({
                     method: 'DELETE',
                     headers: expect.objectContaining(clientOptions.headers)
@@ -392,10 +394,10 @@ describe('MastraClient Resources', () => {
         it('should get memory status', async () => {
             const mockResponse = { result: true };
             mockFetchResponse(mockResponse);
-            const result = await client.getMemoryStatus();
+            const result = await client.getMemoryStatus(agentId);
             expect(result).toEqual(mockResponse);
             expect(global.fetch).toHaveBeenCalledWith(
-                `${clientOptions.baseUrl}/api/memory/status`,
+                `${clientOptions.baseUrl}/api/memory/status?agentId=${agentId}`,
                 expect.objectContaining({
                     headers: expect.objectContaining(clientOptions.headers)
                 })
@@ -412,10 +414,10 @@ describe('MastraClient Resources', () => {
                 createdAt: new Date()
             }];
             mockFetchResponse(messages);
-            const result = await client.saveMessageToMemory({ messages });
+            const result = await client.saveMessageToMemory({ messages, agentId });
             expect(result).toEqual(messages);
             expect(global.fetch).toHaveBeenCalledWith(
-                `${clientOptions.baseUrl}/api/memory/save-messages`,
+                `${clientOptions.baseUrl}/api/memory/save-messages?agentId=${agentId}`,
                 expect.objectContaining({
                     method: 'POST',
                     headers: expect.objectContaining(clientOptions.headers),

--- a/src/resources/memory-thread.ts
+++ b/src/resources/memory-thread.ts
@@ -12,7 +12,8 @@ import { BaseResource } from './base';
 export class MemoryThread extends BaseResource {
     constructor(
         options: ClientOptions,
-        private threadId: string
+        private threadId: string,
+        private agentId: string
     ) {
         super(options);
     }
@@ -22,7 +23,7 @@ export class MemoryThread extends BaseResource {
      * @returns Promise containing thread details including title and metadata
      */
     get(): Promise<StorageThreadType> {
-        return this.request(`/api/memory/threads/${this.threadId}`);
+        return this.request(`/api/memory/threads/${this.threadId}?agentId=${this.agentId}`);
     }
 
     /**
@@ -31,7 +32,7 @@ export class MemoryThread extends BaseResource {
      * @returns Promise containing updated thread details
      */
     update(params: UpdateMemoryThreadParams): Promise<StorageThreadType> {
-        return this.request(`/api/memory/threads/${this.threadId}`, {
+        return this.request(`/api/memory/threads/${this.threadId}?agentId=${this.agentId}`, {
             method: 'PATCH',
             body: params,
         });
@@ -42,7 +43,7 @@ export class MemoryThread extends BaseResource {
      * @returns Promise containing deletion result
      */
     delete(): Promise<{ result: string }> {
-        return this.request(`/api/memory/threads/${this.threadId}`, {
+        return this.request(`/api/memory/threads/${this.threadId}?agentId=${this.agentId}`, {
             method: 'DELETE',
         });
     }
@@ -52,6 +53,6 @@ export class MemoryThread extends BaseResource {
      * @returns Promise containing thread messages and UI messages
      */
     getMessages(): Promise<GetMemoryThreadMessagesResponse> {
-        return this.request(`/api/memory/threads/${this.threadId}/messages`);
+        return this.request(`/api/memory/threads/${this.threadId}/messages?agentId=${this.agentId}`);
     }
 } 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export interface GetVectorIndexResponse {
 
 export interface SaveMessageToMemoryParams {
     messages: MessageType[];
+    agentId: string
 }
 
 export type SaveMessageToMemoryResponse = MessageType[]
@@ -103,12 +104,14 @@ export interface CreateMemoryThreadParams {
     metadata: Record<string, any>;
     resourceid: string;
     threadId: string;
+    agentId: string
 }
 
 export type CreateMemoryThreadResponse = StorageThreadType
 
 export interface GetMemoryThreadParams {
     resourceId: string;
+    agentId: string
 }
 
 export type GetMemoryThreadResponse = StorageThreadType[]


### PR DESCRIPTION
Similarly to https://github.com/mastra-ai/mastra/pull/1826 we need to pass `agentId` to all memory related APIs because memory can now be attached to agents and not just to mastra. Memory is now looked up on the agent and it checks if it has its own memory or should defer to memory attached to mastra.